### PR TITLE
Fix button wrapping and heading color

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,9 @@
             margin-bottom: 20px;
             color: #444;
         }
+        h2 {
+            color: #333;
+        }
         .color-picker-wrapper {
             display: flex;
             align-items: center;
@@ -70,7 +73,7 @@
         }
         button {
             padding: 8px 16px;
-            margin: 0 5px;
+            margin: 5px;
             border: none;
             border-radius: 6px;
             cursor: pointer;
@@ -113,6 +116,7 @@
             background-color: rgba(20,20,20,0.85);
         }
         .dark-mode h1,
+        .dark-mode h2,
         .dark-mode p,
         .dark-mode .color-code {
             color: #eee;


### PR DESCRIPTION
## Summary
- add vertical margins on buttons so wrapping isn't cramped
- ensure recommendation title text is dark in light theme and light in dark theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848d58bf32083299bc4fde4e1b68608