### PR TITLE
Fix favicon centering

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -6,5 +6,5 @@
     </linearGradient>
   </defs>
   <circle cx="50" cy="50" r="45" fill="white" />
-  <text x="50" y="50" text-anchor="middle" dominant-baseline="central" font-size="56" font-family="Segoe UI, Arial, sans-serif" font-weight="bold" fill="url(#gradC)">C</text>
+  <text x="50" y="52" text-anchor="middle" dominant-baseline="middle" font-size="64" font-family="Segoe UI, Arial, sans-serif" font-weight="bold" fill="url(#gradC)">C</text>
 </svg>


### PR DESCRIPTION
## Summary
- center the `C` on the favicon
- slightly enlarge the `C`

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684952bbb5008329a5ed6cb6ee6f40b4